### PR TITLE
Fix `DoEstimateGas` doesn't return evm revert error

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1207,7 +1207,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	hi += uint64(float64(hi) * 0.2)
 
 	// Reject the transaction as invalid if it still fails at the highest allowance
-	if hi == cap {
+	if hi >= cap {
 		failed, result, err := executable(hi)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Inshallah. This PR is to fix the `eth_estimateGas` method work.
Previous code seems to apply the `gas` from the stateful precompile contract. But reverted transaction will get `block.GasLimit()` gas. So the last `executable()` doesn't work.

Is this a known issue?

### Before( error by viem )

```
An error occurred while executing: tx gas limit 60000000 exceeds block max gas 50000000: invalid gas limit: invalid gas limit

Request Arguments:
  chain:  xxx (id: 2061)
  from:   0x20f33CE90A13a4b5E7697E3544c3083B8F8A51D4
  to:     0x18Df82C7E422A42D47345Ed86B0E935E9718eBda
  value:  0 xxx
  data:   0xb67e53a300000000000000000000000036b33d90ca929aa42470344dd3ac76f40454f943

Details: tx gas limit 60000000 exceeds block max gas 50000000: invalid gas limit: invalid gas limit
Docs: https://viem.sh/docs/contract/estimateContractGas.html
Version: viem@1.5.4
```

### After( error by viem )

```
The contract function "emitToken" reverted with the following reason:
User can't receive tokens yet

Contract Call:
  address:   0x18Df82C7E422A42D47345Ed86B0E935E9718eBda
  function:  emitToken(address _to)
  args:  (0x36b33D90CA929AA42470344Dd3ac76F40454F943)
  sender:  0x20f33CE90A13a4b5E7697E3544c3083B8F8A51D4

Docs: https://viem.sh/docs/contract/estimateContractGas.html
Version: viem@1.5.4
```